### PR TITLE
Downgrade rubocop version to match the one in Decidim

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     rubocop-decidim (0.1.0)
-      rubocop
+      rubocop (~> 0.71.0)
 
 GEM
   remote: https://rubygems.org/
@@ -10,13 +10,12 @@ GEM
     ast (2.4.0)
     byebug (11.1.3)
     diff-lcs (1.3)
-    parallel (1.19.1)
+    jaro_winkler (1.5.4)
+    parallel (1.19.2)
     parser (2.7.1.3)
       ast (~> 2.4.0)
     rainbow (3.0.0)
     rake (12.3.3)
-    regexp_parser (1.7.1)
-    rexml (3.2.4)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -30,19 +29,15 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.3)
-    rubocop (0.85.1)
+    rubocop (0.71.0)
+      jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
-      parser (>= 2.7.0.1)
+      parser (>= 2.6)
       rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.7)
-      rexml
-      rubocop-ast (>= 0.0.3)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (0.0.3)
-      parser (>= 2.7.0.1)
+      unicode-display_width (>= 1.4.0, < 1.7)
     ruby-progressbar (1.10.1)
-    unicode-display_width (1.7.0)
+    unicode-display_width (1.6.1)
 
 PLATFORMS
   ruby

--- a/lib/rubocop/cop/decidim/translated_attribute.rb
+++ b/lib/rubocop/cop/decidim/translated_attribute.rb
@@ -54,7 +54,7 @@ module RuboCop
               resource = method_param_chain.children[0].source
               attribute_name = method_param_chain.children[1]
 
-              corrector.replace(node, "translated(#{resource}, :#{attribute_name})")
+              corrector.replace(node.loc.expression, "translated(#{resource}, :#{attribute_name})")
             end
           end
         end

--- a/rubocop-decidim.gemspec
+++ b/rubocop-decidim.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'rubocop', '~> 0.85'
+  spec.add_runtime_dependency 'rubocop', '~> 0.71.0'
 
   spec.add_development_dependency 'byebug'
 end


### PR DESCRIPTION
Decidim uses an outdated Rubocop version (0.71, latest is 0.85 right now). This PR downgrades the Rubocop version to match the one in Decidim, and fixes the custom cop so that it works as expected.